### PR TITLE
Install slapd-contrib to include pbkdf2 pw support

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -33,6 +33,7 @@ RUN echo "path-include /usr/share/doc/krb5*" >> /etc/dpkg/dpkg.cfg.d/docker && a
     libsasl2-modules-sql \
     openssl \
     slapd \
+    slapd-contrib \
     krb5-kdc-ldap \
     && curl -o pqchecker.deb -SL http://www.meddeb.net/pub/pqchecker/deb/8/pqchecker_${PQCHECKER_VERSION}_amd64.deb \
     && echo "${PQCHECKER_MD5} *pqchecker.deb" | md5sum -c - \


### PR DESCRIPTION
#235 discusses inclusion of the pbkdf2 password hash support for openldap. The solution is quite easy - simply add the slapd-contrib module, leading to the following new files

```
root@ae97956e7665:/etc# dpkg -L slapd-contrib
/.
/usr
/usr/lib
/usr/lib/ldap
/usr/lib/ldap/pw-apr1.la
/usr/lib/ldap/pw-apr1.so.0.0.0
/usr/lib/ldap/pw-netscape.la
/usr/lib/ldap/pw-netscape.so.0.0.0
/usr/lib/ldap/pw-pbkdf2.la
/usr/lib/ldap/pw-pbkdf2.so.0.0.0
/usr/lib/ldap/smbk5pwd.la
/usr/lib/ldap/smbk5pwd.so.0.0.0
/usr/share
/usr/share/doc
/usr/share/doc/slapd-contrib
/usr/share/doc/slapd-contrib/changelog.Debian.gz
/usr/share/doc/slapd-contrib/changelog.gz
/usr/share/doc/slapd-contrib/copyright
/usr/share/doc/slapd-contrib/examples
/usr/share/doc/slapd-contrib/examples/apr1-atol.pl
/usr/share/doc/slapd-contrib/examples/apr1-ltoa.pl
/usr/share/lintian
/usr/share/lintian/overrides
/usr/share/lintian/overrides/slapd-contrib
/usr/share/man
/usr/share/man/man5
/usr/share/man/man5/slapo-pw-pbkdf2.5.gz
/usr/share/man/man5/slapo-smbk5pwd.5.gz
/usr/lib/ldap/pw-apr1.so
/usr/lib/ldap/pw-apr1.so.0
/usr/lib/ldap/pw-netscape.so
/usr/lib/ldap/pw-netscape.so.0
/usr/lib/ldap/pw-pbkdf2.so
/usr/lib/ldap/pw-pbkdf2.so.0
/usr/lib/ldap/smbk5pwd.so
/usr/lib/ldap/smbk5pwd.so.0
```
the following additional packages will be addtitionally installed
```
root@ae97956e7665:/etc# apt install slapd-contrib
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  libasn1-8-heimdal libhcrypto4-heimdal libhdb9-heimdal libheimbase1-heimdal libhx509-5-heimdal libkadm5srv8-heimdal libkrb5-26-heimdal libroken18-heimdal libwind0-heimdal
The following NEW packages will be installed:
  libasn1-8-heimdal libhcrypto4-heimdal libhdb9-heimdal libheimbase1-heimdal libhx509-5-heimdal libkadm5srv8-heimdal libkrb5-26-heimdal libroken18-heimdal libwind0-heimdal slapd-contrib
0 upgraded, 10 newly installed, 0 to remove and 14 not upgraded.
Need to get 1,133 kB of archives.
```